### PR TITLE
Support specifying a Proc or a Symbol pointing to a method that checks whether the date validations should be performed.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gov_uk_date_fields (1.0.7)
+    gov_uk_date_fields (1.0.8)
       rails (~> 4.0)
 
 GEM
@@ -54,8 +54,8 @@ GEM
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
@@ -99,7 +99,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
     ruby-progressbar (1.7.1)
-    sprockets (3.5.2)
+    sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.0.1)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ simply add an acts_as_gov_uk_date to your model wth the attribute names of the d
 
 This tells the gem that there are two columns of type date on the database record for this model, ```dob``` and ```joined```, which will be rendered as three boxes on the form.
 
+You can also specify a Proc or a Symbol pointing to a method that checks whether the date validations should be performed. This is optional and by default validations are always performed. Example:
 
+    acts_as_gov_uk_date :dob, :joined, validate_if: :perform_validation?
 
 ### 3. Permit the date parameters in your controller
 

--- a/lib/gov_uk_date_fields/acts_as_gov_uk_date.rb
+++ b/lib/gov_uk_date_fields/acts_as_gov_uk_date.rb
@@ -6,9 +6,12 @@ module GovUkDateFields
     end
 
     module ClassMethods
-      def acts_as_gov_uk_date(*date_fields)
+      DEFAULT_GOV_UK_DATE_OPTIONS = { validate_if: ->{ true } }.freeze
 
-        validate :validate_gov_uk_dates
+      def acts_as_gov_uk_date(*date_fields)
+        options = _extract_supported_options!(date_fields)
+
+        validate :validate_gov_uk_dates, if: options[:validate_if]
 
         after_initialize :populate_gov_uk_dates
 
@@ -102,6 +105,17 @@ module GovUkDateFields
         include GovUkDateFields::ActsAsGovUkDate::LocalInstanceMethods
       end
 
+      protected
+
+      def _supported_options
+        [:validate_if]
+      end
+
+      def _extract_supported_options!(args)
+        options = DEFAULT_GOV_UK_DATE_OPTIONS.merge(args.extract_options!)
+        options.assert_valid_keys(*_supported_options)
+        options
+      end
     end
 
     module LocalInstanceMethods
@@ -115,8 +129,6 @@ module GovUkDateFields
       #   MojDateFields::FormDate.set_from_date(self, :first_day_of_trial, self['first_day_of_trial'])
       # end
     end
-
-
   end
 end
 

--- a/lib/gov_uk_date_fields/version.rb
+++ b/lib/gov_uk_date_fields/version.rb
@@ -1,3 +1,3 @@
 module GovUkDateFields
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/test/dummy/app/models/director.rb
+++ b/test/dummy/app/models/director.rb
@@ -1,0 +1,9 @@
+class Director < Employee
+
+  acts_as_gov_uk_date :dob, :joined, validate_if: :perform_validation?
+
+  def perform_validation?
+    false
+  end
+
+end

--- a/test/dummy/test/models/director_test.rb
+++ b/test/dummy/test/models/director_test.rb
@@ -1,0 +1,48 @@
+require 'pp'
+require File.dirname(__FILE__) + '/../../../test_helper'
+require File.dirname(__FILE__) + '/../../../../lib/gov_uk_date_fields/gov_uk_date_fields'
+
+
+class DirectorTest < ActiveSupport::TestCase
+
+  def setup
+    @director = Director.new(name: 'John', dob: Date.new(1963, 8, 13), joined: Date.new(2014, 4, 21))
+  end
+
+  def test_director_class_responds_to_acts_as_gov_uk_date
+    assert(Director.respond_to?(:acts_as_gov_uk_date), 'Director class does not respond to method :gov_uk_date_fields')
+  end
+
+  def test_director_has_class_variable_describing_all_gov_uk_dates
+    assert_equal([:dob, :joined], Director._gov_uk_dates)
+  end
+
+  def test_valid_dates_raise_no_errors_when_validation_disabled
+    assert_true @director.valid?, '@director.valid?'
+  end
+
+  def test_nil_dates_raise_no_errors_when_validation_disabled
+    @director.dob = nil
+    assert_true @director.valid?, '@director.valid?'
+  end
+
+  def test_invalid_day_raises_no_error_when_validation_disabled
+    @director.dob_dd = '32'
+    assert_true @director.valid?
+    assert_equal [], @director.errors[:dob]
+  end
+
+  def test_creating_a_new_director_with_invalid_dates_is_valid_when_validation_disabled
+    e = Director.new(name: 'Stephen', dob_dd: '13', dob_mm: 'XXX', dob_yyyy: '1963')
+    assert_equal nil, e.dob
+    assert_true e.valid?
+  end
+
+  def test_updating_existing_record_with_invalid_dates_is_valid_when_validation_disabled
+    @director.save!
+    assert_equal Date.new(1963, 8, 13), @director.dob
+    @director.update(dob_dd: '47', dob_mm: '5', dob_yyyy: '1965')
+    assert_equal Date.new(1963, 8, 13), @director.dob
+    assert_true @director.valid?
+  end
+end


### PR DESCRIPTION
Support for a Proc or a Symbol pointing to a method that checks whether the date validations should be performed. This is optional and by default validations are always performed. Example:

    acts_as_gov_uk_date :dob, :joined, validate_if: :perform_validation?

Updated README and bumped version to 1.0.8