### PR TITLE
Remove pattern and change max year value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gov_uk_date_fields (1.0.8)
+    gov_uk_date_fields (1.0.9)
       rails (~> 4.0)
 
 GEM

--- a/lib/gov_uk_date_fields/form_fields.rb
+++ b/lib/gov_uk_date_fields/form_fields.rb
@@ -129,7 +129,7 @@ module GovUkDateFields
       %Q|
           <div class="form-group form-group-day">
             <label for="#{html_id(:day)}">Day</label>
-            <input class="form-control" id="#{html_id(:day)}" name="#{html_name(:day)}" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="#{@attribute}-hint" #{generate_day_value}>
+            <input class="form-control" id="#{html_id(:day)}" name="#{html_name(:day)}" type="number" min="0" max="31" aria-describedby="#{@attribute}-hint" #{generate_day_value}>
           </div>
       |
     end
@@ -138,7 +138,7 @@ module GovUkDateFields
       %Q|
         <div class="form-group form-group-month">
           <label for="#{html_id(:month)}">Month</label>
-          <input class="form-control" id="#{html_id(:month)}" name="#{html_name(:month)}" type="number" pattern="[0-9]*" min="0" max="12" #{generate_month_value}>
+          <input class="form-control" id="#{html_id(:month)}" name="#{html_name(:month)}" type="number" min="0" max="12" #{generate_month_value}>
         </div>
       |
     end
@@ -147,7 +147,7 @@ module GovUkDateFields
       %Q|
         <div class="form-group form-group-year">
           <label for="#{html_id(:year)}">Year</label>
-          <input class="form-control" id="#{html_id(:year)}" name="#{html_name(:year)}" type="number" pattern="[0-9]*" min="0" max="#{Date.today.year}" #{generate_year_value}>
+          <input class="form-control" id="#{html_id(:year)}" name="#{html_name(:year)}" type="number" min="0" max="2100" #{generate_year_value}>
         </div>
       |
     end

--- a/lib/gov_uk_date_fields/version.rb
+++ b/lib/gov_uk_date_fields/version.rb
@@ -1,3 +1,3 @@
 module GovUkDateFields
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end

--- a/test/form_fields_test.rb
+++ b/test/form_fields_test.rb
@@ -107,15 +107,15 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
           <p class="form-hint" id="joined-hint">For example, 31 3 1980</p>
           <div class="form-group form-group-day">
             <label for="employee_joined_dd">Day</label>
-            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="joined-hint" value="1">
+            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="joined-hint" value="1">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_joined_mm">Month</label>
-            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" pattern="[0-9]*" min="0" max="12" value="4">
+            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" min="0" max="12" value="4">
           </div>
           <div class="form-group form-group-year">
             <label for="employee_joined_yyyy">Year</label>
-            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" pattern="[0-9]*" min="0" max="2016" value="2015">
+            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" min="0" max="2100" value="2015">
           </div>
         </div>
       </fieldset>
@@ -130,15 +130,15 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
           <p class="form-hint" id="joined-hint">For example, 31 3 1980</p>
           <div class="form-group form-group-day">
             <label for="employee_joined_dd">Day</label>
-            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="joined-hint" value="1">
+            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="joined-hint" value="1">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_joined_mm">Month</label>
-            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" pattern="[0-9]*" min="0" max="12" value="4">
+            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" min="0" max="12" value="4">
           </div>
           <div class="form-group form-group-year">
             <label for="employee_joined_yyyy">Year</label>
-            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" pattern="[0-9]*" min="0" max="2016" value="2015">
+            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" min="0" max="2100" value="2015">
           </div>
         </div>
       </fieldset>
@@ -153,15 +153,15 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
           <p class="form-hint" id="dob-hint">In the form: dd mm yyyy</p>
           <div class="form-group form-group-day">
             <label for="employee_dob_dd">Day</label>
-            <input class="form-control" id="employee_dob_dd" name="employee[dob_dd]" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint" value="7">
+            <input class="form-control" id="employee_dob_dd" name="employee[dob_dd]" type="number" min="0" max="31" aria-describedby="dob-hint" value="7">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_dob_mm">Month</label>
-            <input class="form-control" id="employee_dob_mm" name="employee[dob_mm]" type="number" pattern="[0-9]*" min="0" max="12" value="12">
+            <input class="form-control" id="employee_dob_mm" name="employee[dob_mm]" type="number" min="0" max="12" value="12">
           </div>
           <div class="form-group form-group-year">
             <label for="employee_dob_yyyy">Year</label>
-            <input class="form-control" id="employee_dob_yyyy" name="employee[dob_yyyy]" type="number" pattern="[0-9]*" min="0" max="2016" value="1963">
+            <input class="form-control" id="employee_dob_yyyy" name="employee[dob_yyyy]" type="number" min="0" max="2100" value="1963">
           </div>
         </div>
       </fieldset>
@@ -176,15 +176,15 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
           <p class="form-hint" id="joined-hint">For example, 31 3 1980</p>
           <div class="form-group form-group-day">
             <label for="employee_joined_dd">Day</label>
-            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="joined-hint" value="1">
+            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="joined-hint" value="1">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_joined_mm">Month</label>
-            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" pattern="[0-9]*" min="0" max="12" value="4">
+            <input class="form-control" id="employee_joined_mm" name="employee[joined_mm]" type="number" min="0" max="12" value="4">
           </div>
           <div class="form-group form-group-year">
             <label for="employee_joined_yyyy">Year</label>
-            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" pattern="[0-9]*" min="0" max="#{Date.today.year}" value="2015">
+            <input class="form-control" id="employee_joined_yyyy" name="employee[joined_yyyy]" type="number" min="0" max="2100" value="2015">
           </div>
         </div>
       </fieldset>


### PR DESCRIPTION
Previously there was a "pattern" attribute on each of the html input fields.

This contravenes the W3C standards for fields with type="number", and so has been removed.

Also, the maximum value for the year field was set to the value of the current year, which would
entry of dates in the future.  As this gem is intended for generalised use, the maximum value has
been set to 2100, and the client should validate as necessary.