### PR TITLE
Don't pin the gem for Rails 4 only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     gov_uk_date_fields (1.0.9)
-      rails (~> 4.0)
+      rails (>= 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -46,7 +46,7 @@ GEM
     arel (6.0.3)
     awesome_print (1.6.1)
     builder (3.2.2)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -57,8 +57,10 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
-    mime-types (2.99.1)
-    mini_portile2 (2.0.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     minitest-reporters (1.1.7)
       ansi
@@ -67,9 +69,11 @@ GEM
       ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     pg (0.18.2)
+    pkg-config (1.1.7)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -97,12 +101,12 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.5.0)
+    rake (11.2.2)
     ruby-progressbar (1.7.1)
     sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.1)
+    sprockets-rails (3.0.4)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/gov_uk_date_fields.gemspec
+++ b/gov_uk_date_fields.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0"
+  s.add_dependency "rails", ">= 4.0"
 
   s.add_development_dependency "pg", "~> 0.18.0"
   s.add_development_dependency "awesome_print", "~> 1.6"

--- a/lib/gov_uk_date_fields/version.rb
+++ b/lib/gov_uk_date_fields/version.rb
@@ -1,3 +1,3 @@
 module GovUkDateFields
-  VERSION = "1.0.9"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Relaxed the requirement so that the gem can be used with Rails 5 too.

[This](https://github.com/ministryofjustice/gov_uk_date_fields/compare/rails-version-bump-up?expand=1#diff-11a00d69119ff77d27a307974e9fcd72R22) is the only **major** change