### PR TITLE
Hint id to be based on fieldset id if specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The FormBuilder method gov_uk_date_field takes two parameters:
       the text "For example, 31 3 1980" will be used.
       
     - **id**: The id to be given to the fieldset.  If absent, no id will be assigned to the fieldset.  This setting also affects the id of the hint element:
-      if specified, then the hint element will have the fieldset id appended by '-hint', otherwise it will have the attribute name appeneded by '-hint'.  The hint-id is
+      if specified, then the hint element will have the fieldset id appended by '-hint', otherwise it will have the attribute name appended by '-hint'.  The hint-id is
       referred to by the aria-described-by attribute on the input element.
 
     - **error_messages**: Error messages to be attached to the field, if not the string in the errors collection of the object.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The FormBuilder method gov_uk_date_field takes two parameters:
     - **form_hint_text**: The text that is to advise the user how to fill in the form.  If not specified, 
       the text "For example, 31 3 1980" will be used.
       
-    - **id**: The id to be given to the fieldset.  If absent, no id will be assigned to the fieldset.
+    - **id**: The id to be given to the fieldset.  If absent, no id will be assigned to the fieldset.  This setting also affects the id of the hint element:
+      if specified, then the hint element will have the fieldset id appended by '-hint', otherwise it will have the attribute name appeneded by '-hint'.  The hint-id is
+      referred to by the aria-described-by attribute on the input element.
 
     - **error_messages**: Error messages to be attached to the field, if not the string in the errors collection of the object.
       This is useful if the error messages are held in a translation file for example - the client should fetch the translations and

--- a/lib/gov_uk_date_fields/form_fields.rb
+++ b/lib/gov_uk_date_fields/form_fields.rb
@@ -28,6 +28,7 @@ module GovUkDateFields
       @fieldset_required  = false
       @fieldset_id        = @options[:id]
       @error_messages     = @options[:error_messages]
+      @hint_id            = @fieldset_id.nil? ? "#{@attribute}-hint" : "#{@fieldset_id}-hint"
       parse_options
     end
 
@@ -67,7 +68,7 @@ module GovUkDateFields
           #{generate_legend_tag}#{@options[:legend_text]}</legend>
           <div class="form-date">
             #{generate_error_message}
-            <p class="form-hint" id="#{@attribute}-hint">#{@form_hint_text}</p>
+            <p class="form-hint" id="#{@hint_id}">#{@form_hint_text}</p>
       |
     end
 
@@ -129,7 +130,7 @@ module GovUkDateFields
       %Q|
           <div class="form-group form-group-day">
             <label for="#{html_id(:day)}">Day</label>
-            <input class="form-control" id="#{html_id(:day)}" name="#{html_name(:day)}" type="number" min="0" max="31" aria-describedby="#{@attribute}-hint" #{generate_day_value}>
+            <input class="form-control" id="#{html_id(:day)}" name="#{html_name(:day)}" type="number" min="0" max="31" aria-describedby="#{@hint_id}" #{generate_day_value}>
           </div>
       |
     end

--- a/lib/gov_uk_date_fields/version.rb
+++ b/lib/gov_uk_date_fields/version.rb
@@ -1,3 +1,3 @@
 module GovUkDateFields
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/test/form_fields_test.rb
+++ b/test/form_fields_test.rb
@@ -104,10 +104,10 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
               <span class="error-message">Joining date must be in the past</span>
             </li>
           </ul>
-          <p class="form-hint" id="joined-hint">For example, 31 3 1980</p>
+          <p class="form-hint" id="employee_date_joined-hint">For example, 31 3 1980</p>
           <div class="form-group form-group-day">
             <label for="employee_joined_dd">Day</label>
-            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="joined-hint" value="1">
+            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="employee_date_joined-hint" value="1">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_joined_mm">Month</label>
@@ -127,10 +127,10 @@ class GovUkDateFieldsTest < ActiveSupport::TestCase
       <fieldset id="employee_date_joined">
         <legend>Joining date</legend>
         <div class="form-date">
-          <p class="form-hint" id="joined-hint">For example, 31 3 1980</p>
+          <p class="form-hint" id="employee_date_joined-hint">For example, 31 3 1980</p>
           <div class="form-group form-group-day">
             <label for="employee_joined_dd">Day</label>
-            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="joined-hint" value="1">
+            <input class="form-control" id="employee_joined_dd" name="employee[joined_dd]" type="number" min="0" max="31" aria-describedby="employee_date_joined-hint" value="1">
           </div>
           <div class="form-group form-group-month">
             <label for="employee_joined_mm">Month</label>


### PR DESCRIPTION
This is to prevent multiple elements having the same id, as would be the case for nested elements relating to the same attribute
