### PR TITLE
Add option to control behaviour of multiple error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ simply add an acts_as_gov_uk_date to your model wth the attribute names of the d
 
 This tells the gem that there are two columns of type date on the database record for this model, ```dob``` and ```joined```, which will be rendered as three boxes on the form.
 
+#### 2.1 Options that can be passed to ```acts_as_gov_uk_date```
+
+ * ```:validate_if``` Determines whether or not to validate the date as part of the model's validation routines.  Pass in the name of a method which returns true or false. If
+   not specified, true is assumed.
+
+ * ```:error_clash_behaviour``` - Determines what action to take with multiple error messages if the model's validation has added an error message to the errors hash for this field, and this gem also determines
+   that it is invalid.  Possible values are:
+   *  :append_gov_uk_date_field_error - This gem's 'Invalid date' message will be added to the errors hash, resulting in both error messages being displayed
+   *  :omit_gov_uk_date_field_error - The gem's 'Invalid date' message is discarded - ony the model's validation error message will be displayed
+   *  :override_with_gov_uk_date_field_error - The model's error message is discarded and this gem's 'Invalid date' message added to the error hash.  Only the invalid date will be displayed.
+
+   If the ```:error_clash_behaviour``` option is not specified, ```:append_gov_uk_date_field_error``` is assumed.
+
+#### 2.2 Examples
+
+    acts_as_gov_uk_date :date_of_birth, :date_joined, 
+                        validate_if: :perform_validation?, 
+                        error_clash_behaviour: :override_with_gov_uk_date_field_error
+
+    def perform_validation?
+      return true unless self.draft?
+    end
+
+
 You can also specify a Proc or a Symbol pointing to a method that checks whether the date validations should be performed. This is optional and by default validations are always performed. Example:
 
     acts_as_gov_uk_date :dob, :joined, validate_if: :perform_validation?

--- a/test/dummy/app/models/default_error_clash_employee.rb
+++ b/test/dummy/app/models/default_error_clash_employee.rb
@@ -1,0 +1,8 @@
+class DefaultErrorClashEmployee < Employee
+
+  acts_as_gov_uk_date :dob, :joined
+
+  validates :dob, presence: true
+  validates :joined, presence: true
+
+end

--- a/test/dummy/app/models/employee.rb
+++ b/test/dummy/app/models/employee.rb
@@ -3,3 +3,4 @@ class Employee < ActiveRecord::Base
   acts_as_gov_uk_date :dob, :joined
 
 end
+

--- a/test/dummy/app/models/omit_error_clash_employee.rb
+++ b/test/dummy/app/models/omit_error_clash_employee.rb
@@ -1,0 +1,8 @@
+class OmitErrorClashEmployee < Employee
+
+  acts_as_gov_uk_date :dob, :joined, error_clash_behaviour: :omit_gov_uk_date_field_error
+
+  validates :dob, presence: true
+  validates :joined, presence: true
+
+end

--- a/test/dummy/app/models/override_error_clash_employee.rb
+++ b/test/dummy/app/models/override_error_clash_employee.rb
@@ -1,0 +1,23 @@
+class MyValidator < ActiveModel::Validator
+  def validate(record)
+    [:dob, :joined].each do |date_field|
+      if record.__send__(date_field).nil?
+        record.errors[date_field] << "Can't be blank"
+      end
+    end
+  end
+end
+
+
+
+
+class OverrideErrorClashEmployee < Employee
+
+  validates_with MyValidator
+
+  acts_as_gov_uk_date :dob, :joined, error_clash_behaviour: :override_with_gov_uk_date_field_error
+
+
+
+end
+

--- a/test/dummy/test/models/default_error_clash_employee_test.rb
+++ b/test/dummy/test/models/default_error_clash_employee_test.rb
@@ -1,0 +1,33 @@
+require 'pp'
+require File.dirname(__FILE__) + '/../../../test_helper'
+require File.dirname(__FILE__) + '/../../../../lib/gov_uk_date_fields/gov_uk_date_fields'
+
+
+class DefaultErrorClashEmployeeTest < ActiveSupport::TestCase
+
+
+  def setup
+    @employee = DefaultErrorClashEmployee.new(name: 'John', dob: nil, joined: nil)
+  end
+
+  def test_presence_error_messages_generated
+    @employee.valid?
+    assert_equal ["can't be blank"], @employee.errors[:dob]
+    assert_equal ["can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_invalid_day_adds_invalid_date_message_to_cant_be_blank_message
+    @employee.dob_dd = '32'
+    assert_false @employee.valid?
+    assert_equal ['Invalid date', "can't be blank"], @employee.errors[:dob]
+    assert_equal ["can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_valid_dates_generate_no_errors_at_all
+    @employee.dob_dd = '15'
+    @employee.dob_mm = '8'
+    @employee.dob_yyyy = '2016'
+    assert_empty @employee.errors[:dob]
+  end
+end
+

--- a/test/dummy/test/models/omit_error_clash_employee_test.rb
+++ b/test/dummy/test/models/omit_error_clash_employee_test.rb
@@ -1,0 +1,34 @@
+require 'pp'
+require File.dirname(__FILE__) + '/../../../test_helper'
+require File.dirname(__FILE__) + '/../../../../lib/gov_uk_date_fields/gov_uk_date_fields'
+
+
+class OmitErrorClashEmployeeTest < ActiveSupport::TestCase
+
+
+  def setup
+    @employee = OmitErrorClashEmployee.new(name: 'John', dob: nil, joined: nil)
+  end
+
+  def test_presence_error_messages_generated
+    @employee.valid?
+    assert_equal ["can't be blank"], @employee.errors[:dob]
+    assert_equal ["can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_invalid_day_does_not_add_invalid_date_message_to_cant_be_blank_message
+    @employee.dob_dd = '32'
+    @employee.joined_mm = '77'
+    assert_false @employee.valid?
+    assert_equal ["can't be blank"], @employee.errors[:dob]
+    assert_equal ["can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_valid_dates_generate_no_errors_at_all
+    @employee.dob_dd = '15'
+    @employee.dob_mm = '8'
+    @employee.dob_yyyy = '2016'
+    assert_empty @employee.errors[:dob]
+  end
+end
+

--- a/test/dummy/test/models/overrride_error_clash_employee_test.rb
+++ b/test/dummy/test/models/overrride_error_clash_employee_test.rb
@@ -1,0 +1,33 @@
+require 'pp'
+require File.dirname(__FILE__) + '/../../../test_helper'
+require File.dirname(__FILE__) + '/../../../../lib/gov_uk_date_fields/gov_uk_date_fields'
+
+
+class OverrideErrorClashEmployeeTest < ActiveSupport::TestCase
+
+
+  def setup
+    @employee = OverrideErrorClashEmployee.new(name: 'John', dob: nil, joined: nil)
+  end
+
+  def test_presence_error_messages_generated
+    @employee.valid?
+    assert_equal ["Can't be blank"], @employee.errors[:dob]
+    assert_equal ["Can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_invalid_day_overrides_cant_be_blank_message
+    @employee.dob_mm = '77'
+    assert_false @employee.valid?
+    assert_equal ["Invalid date"], @employee.errors[:dob]
+    assert_equal ["Can't be blank"], @employee.errors[:joined]
+  end
+
+  def test_valid_dates_generate_no_errors_at_all
+    @employee.dob_dd = '15'
+    @employee.dob_mm = '8'
+    @employee.dob_yyyy = '2016'
+    assert_empty @employee.errors[:dob]
+  end
+end
+


### PR DESCRIPTION
If invalid values are entered on a gov_uk_date_field,  e.g. 35/16/2016,
this gem will add an Invalid date error message to the error hash for the field,
but the underlying model may also have added a message, such as "Cannot be blank"
(because the date field will be nil in this case).

This PR adds a new option to the acts_as_gov_uk_date_field method to allow the
client to control the behaviour in this case, either displaying both error messages,
dropping the gem-generated error message or dropping the model-generated error message.