### PR TITLE
Improve attribute accessor compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 group :test, :development do
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'minitest-reporters', '~> 1.1', '>= 1.1.7'
   gem 'pg', '~> 0.18.4'
   gem 'awesome_print', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
     arel (7.1.4)
     awesome_print (1.7.0)
     builder (3.2.3)
+    byebug (10.0.2)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     erubis (2.7.0)
     globalid (0.4.0)
@@ -75,6 +77,12 @@ GEM
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     pg (0.18.4)
+    pry (0.11.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -131,6 +139,8 @@ DEPENDENCIES
   minitest-reporters (~> 1.1, >= 1.1.7)
   mocha (~> 1.1)
   pg (~> 0.18.4)
+  pry
+  pry-byebug
   rails-controller-testing (~> 1.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ invalid in the model's errors hash during the validation cycle, and the entered 
 the user on the form.
 
 
+## Developing
+
+### Testing
+
+Run tests either with the rake task:
+
+    bundle exec rake test
+
+Or run test files directly from the command-line:
+
+    bundle exec ruby -I. test/dummy/test/models/form_date_test.rb
+
+    # You can run with on a specific test by name
+    bundle exec ruby -I. test/dummy/test/models/employee_test.rb -n test_creating_a_new_employee_with_invalid_dates_is_invalid
+
+
 ## FAQs
 
 ### What is the HTML that this gem produces?

--- a/lib/gov_uk_date_fields/acts_as_gov_uk_date.rb
+++ b/lib/gov_uk_date_fields/acts_as_gov_uk_date.rb
@@ -64,32 +64,28 @@ module GovUkDateFields
         #
         date_fields.each do |field|
 
-          # #dob -return @_dob.date
-          define_method(field) do
-            return self.instance_variable_get("@_#{field}".to_sym).date
-          end
-
           # #dob=(date) = assigns a date to the GovukDateFields::FormDate object
           define_method("#{field}=") do |new_date|
             raise ArgumentError.new("#{new_date} is not a Date object") unless new_date.respond_to?(:to_date) || new_date.nil?
             new_date = new_date.to_date unless new_date.nil?
             GovUkDateFields::FormDate.set_from_date(self, field, new_date)
+            super(new_date)
           end
 
           # #dob_dd   - return the day value for form population
           define_method("#{field}_dd") do
             return self.instance_variable_get("@_#{field}".to_sym).dd
-          end       
+          end
 
           # #dob_mm   - return the day value for form population
           define_method("#{field}_mm") do
             return self.instance_variable_get("@_#{field}".to_sym).mm
-          end    
+          end
 
           # #dob_yyyy   - return the day value for form population
           define_method("#{field}_yyyy") do
             return self.instance_variable_get("@_#{field}".to_sym).yyyy
-          end  
+          end
 
           # #dob_dd= - set the day part of the date (used in population of model from form)
           define_method("#{field}_dd=") do |day| 

--- a/lib/gov_uk_date_fields/form_date.rb
+++ b/lib/gov_uk_date_fields/form_date.rb
@@ -25,18 +25,18 @@ module GovUkDateFields
       else
         form_date = new(date.day.to_s, date.month.to_s, date.year.to_s, date)
       end
-      update_object(object, attr_name, form_date)
+      object.instance_variable_set("@_#{attr_name}", form_date)
     end
 
 
-    
+
     def self.set_date_part(date_part, object, attr_name, value)
       form_date = object.instance_variable_get("@_#{attr_name}".to_sym) || FormDate.nil_date
       form_date.send("#{date_part}=", value)
       form_date.create_date_from_date_parts
-      FormDate.update_object(object, attr_name, form_date)
+      object.__send__("#{attr_name}=", form_date.date)
+      object.instance_variable_set("@_#{attr_name}", form_date)
     end
-
 
     def self.nil_date
       new('', '', '')
@@ -87,14 +87,6 @@ module GovUkDateFields
       @mm = @temp[:mm]
       @yyyy = @temp[:yyyy]
     end
-
-    
-
-    def self.update_object(object, attr_name, form_date)
-      object.instance_variable_set("@_#{attr_name}".to_sym, form_date)
-      object[attr_name] = form_date.date
-    end
-
 
     def self.attr_not_present_in_params?(attr_name, params)
       attr_missing_in_params?(attr_name, params)  || all_blanks_in_params?(attr_name, params)

--- a/test/dummy/app/models/replicant.rb
+++ b/test/dummy/app/models/replicant.rb
@@ -1,0 +1,19 @@
+class Replicant < Employee
+  def self.synchronise_dates(*date_fields)
+    setters = Module.new do
+      date_fields.each do |date_field|
+        define_method("#{date_field}=") do |value|
+          super(value)
+          (date_fields - [date_field]).each do |other_date_field|
+            write_attribute(other_date_field, value)
+          end
+        end
+      end
+    end
+    include setters
+  end
+
+  synchronise_dates   :dob, :joined
+  acts_as_gov_uk_date :dob, :joined
+
+end

--- a/test/dummy/test/models/replicant_test.rb
+++ b/test/dummy/test/models/replicant_test.rb
@@ -1,0 +1,11 @@
+require 'pp'
+require File.dirname(__FILE__) + '/../../../test_helper'
+require File.dirname(__FILE__) + '/../../../../lib/gov_uk_date_fields/gov_uk_date_fields'
+
+
+class ReplicantTest < ActiveSupport::TestCase
+  test 'joined date is same as dob' do
+    @roy = Replicant.new(name: 'Roy', dob: Date.new(2016, 1, 8))
+    assert_equal(@roy.dob, @roy.joined)
+  end
+end


### PR DESCRIPTION
Change the write accessor defined in this library to rely on 'super' instead of
the writer method 'object[attr_name]=', with the implication that writing the
date now has to happen in the write accessor.

While implementing gov uk date fields with jsonb attributes, we were running
into an issue with dates that act as gov uk dates. The dates were not being
saved properly to the JSON. On investigation we found that this was because the
gov_uk_date_fields library was writing attributes with 'object[attr_name]=' and
reading them with 'object[attr_name]' instead of 'object.attr_name=' and
'object.attr_name'. The jsonb_accessor (and incidentally other libraries like
papertrail) override 'object.attr_name=' and can be re-used in a writer method
by calling 'super'.