### PR TITLE
Fix rails 6.1 deprecation warnings

### DIFF
--- a/lib/gov_uk_date_fields/form_fields.rb
+++ b/lib/gov_uk_date_fields/form_fields.rb
@@ -58,7 +58,15 @@ module GovUkDateFields
     end
 
     def error_for_attr?
-      @object.errors.keys.include?(@attribute) && @object.errors[@attribute].any?
+      error_attribute_names.include?(@attribute) && @object.errors[@attribute].any?
+    end
+
+    def error_attribute_names
+      if @object.errors.respond_to?(:attribute_names)
+        @object.errors.attribute_names
+      else
+        @object.errors.keys
+      end
     end
 
     def html_id(date_segment)


### PR DESCRIPTION
#### What
Fix ActiveModel::Error#keys deprecation warning in rails 6.1

#### Why
Fixes the following warning in Rails 6.1 and protects against breakage in 6.2
```
DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.
To achieve the same use:
  errors.attribute_names
```