### PR TITLE
Bump version 3.2.0.rc3 --> 3.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    gov_uk_date_fields (3.2.0.rc3)
-      rails (~> 6.0)
+    gov_uk_date_fields (3.2.0)
+      rails (>= 5.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gov_uk_date_fields.gemspec
+++ b/gov_uk_date_fields.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib", "vendor"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '~> 6.0'
+  s.add_dependency 'rails', '>= 5.2'
 end

--- a/lib/gov_uk_date_fields/version.rb
+++ b/lib/gov_uk_date_fields/version.rb
@@ -1,4 +1,4 @@
 module GovUkDateFields
-  VERSION = "3.2.0.rc3"
-  VERSION_RELEASED = "2021-06-14"
+  VERSION = "3.2.0"
+  VERSION_RELEASED = "2021-06-16"
 end


### PR DESCRIPTION
#### What
Bump version 3.2.0.rc3 --> 3.2.0

#### Why
We have tested 3.2.0.rc3 against a full rails 6.1
application and not found any further issues.

we also should drop support for all but EoL versions
of rails (5.2 being the oldest still supported version
, see https://endoflife.date/rails for details).